### PR TITLE
Enable password set in case of rescued instances

### DIFF
--- a/cloudbaseinit/tests/plugins/windows/test_setuserpassword.py
+++ b/cloudbaseinit/tests/plugins/windows/test_setuserpassword.py
@@ -100,6 +100,8 @@ class SetUserPasswordPluginTests(unittest.TestCase):
         mock_get_key.return_value = ssh_pub_key
         mock_encrypt_password.return_value = 'encrypted password'
         mock_service.post_password.return_value = 'value'
+        mock_service.can_post_password = True
+        mock_service.is_password_set = False
         response = self._setpassword_plugin._set_metadata_password(
             fake_passw0rd, mock_service)
         if ssh_pub_key is None:
@@ -159,4 +161,4 @@ class SetUserPasswordPluginTests(unittest.TestCase):
                                                   'fake username')
         mock_set_metadata_password.assert_called_once_with('fake password',
                                                            mock_service)
-        self.assertEqual((2, False), response)
+        self.assertEqual((1, False), response)


### PR DESCRIPTION
In the case of rescued instances, the user password has already
been set for an instance, and it cannot be posted anymore to the
http metadata service. In this case we still have to set the new
password and warn the user that the password has already been
posted to the metadata service and it cannot be changed anymore.

Change-Id: I9b52af6bf8bac2c394bc4a9eb30a983594fa1e68
Closes-Bug: #1391818