### PR TITLE
appveyor: print Python binary architecture

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ build: off
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   - "%CMD_IN_ENV% python -m pip install -U pip"
   - "%CMD_IN_ENV% python -m pip install -U wheel"
   - "%CMD_IN_ENV% python -m pip install -U GitPython"


### PR DESCRIPTION
It's important to make sure that appveyor actually uses the specified
Python binary architecture. We'll log it as part of the "install"
step.

Change-Id: I4c60fd354a7967d0fb52913a9088b057e0bd60fb